### PR TITLE
Update .eslintrc to allow indentation of switch cases

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
 		"jasmine": true
 	},
 	"rules": {
-		"indent": [1, "tab"],
+		"indent": [1, "tab", { "SwitchCase": 1 }],
 		"linebreak-style": [2, "unix"],
 		"quotes": [1, "single"],
 		"semi": [1, "never"],


### PR DESCRIPTION
Previous rules required:
```
switch (x) {
case a: {}
case b: {}
}
```

this change allows indenting case with a tab:
```
switch (y) {
  case c: {}
  case d: {}
}
```