### PR TITLE
Added exception for 0 in the no magic numbers clause in .eslint file.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
 		"no-unexpected-multiline": 2,
 		"no-unreachable": 2,
 		"no-empty-function": 2,
-		"no-magic-numbers": 1,
+		"no-magic-numbers": [1, { "ignore": [0] }],
 		"no-multi-str": 1,
 		"no-self-assign": 2,
 		"yoda": 2,


### PR DESCRIPTION
Given that 0 is generally used for an obvious reason, it makes sense to exclude this from the linter's no magic numbers clause.
